### PR TITLE
Add support for custom Embeds

### DIFF
--- a/src/Pagination.ts
+++ b/src/Pagination.ts
@@ -3,6 +3,7 @@ import {
   ContextMenuInteraction,
   Message,
   MessageComponentInteraction,
+  MessageEmbed,
 } from "discord.js";
 import { Options } from "../types";
 import { PaginationEmbed } from "./PaginationEmbed";
@@ -10,7 +11,7 @@ import { PaginationEmbed } from "./PaginationEmbed";
 /**
  * The pagination class.
  */
-export class Pagination extends PaginationEmbed {
+export class Pagination<Embed = MessageEmbed> extends PaginationEmbed<Embed> {
   //#region public fields
 
   /**

--- a/src/Pagination.ts
+++ b/src/Pagination.ts
@@ -3,7 +3,6 @@ import {
   ContextMenuInteraction,
   Message,
   MessageComponentInteraction,
-  MessageEmbed,
 } from "discord.js";
 import { Options } from "../types";
 import { PaginationEmbed } from "./PaginationEmbed";
@@ -11,7 +10,7 @@ import { PaginationEmbed } from "./PaginationEmbed";
 /**
  * The pagination class.
  */
-export class Pagination<Embed = MessageEmbed> extends PaginationEmbed<Embed> {
+export class Pagination extends PaginationEmbed {
   //#region public fields
 
   /**

--- a/src/PaginationEmbed.ts
+++ b/src/PaginationEmbed.ts
@@ -6,6 +6,7 @@ import {
   MessageAttachment,
   MessageButton,
   MessageEmbed,
+  MessageEmbedOptions,
 } from "discord.js";
 import {
   ButtonsOptions,
@@ -16,10 +17,12 @@ import {
 } from "../types";
 import { defaultOptions } from "./defaultOptions";
 
+type Embed = MessageEmbed | MessageEmbedOptions;
+
 /**
  * The PaginationEmbed class.
  */
-export class PaginationEmbed<Embed = MessageEmbed> extends MessageEmbed {
+export class PaginationEmbed extends MessageEmbed {
   //#region public fields
 
   /**
@@ -433,7 +436,7 @@ export class PaginationEmbed<Embed = MessageEmbed> extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new Embed(), new Embed(), new Embed()]);
+   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()]);
    * ```
    *
    */
@@ -450,8 +453,8 @@ export class PaginationEmbed<Embed = MessageEmbed> extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new Embed(), new Embed(), new Embed()])
-   *  .addEmbed(new Embed);
+   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()])
+   *  .addEmbed(new MessageEmbed);
    * ```
    *
    */
@@ -467,8 +470,8 @@ export class PaginationEmbed<Embed = MessageEmbed> extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new Embed(), new Embed(), new Embed()])
-   *  .addEmbeds([new Embed(), new Embed(), new Embed()]);
+   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()])
+   *  .addEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()]);
    * ```
    *
    */

--- a/src/PaginationEmbed.ts
+++ b/src/PaginationEmbed.ts
@@ -19,7 +19,7 @@ import { defaultOptions } from "./defaultOptions";
 /**
  * The PaginationEmbed class.
  */
-export class PaginationEmbed extends MessageEmbed {
+export class PaginationEmbed<Embed = MessageEmbed> extends MessageEmbed {
   //#region public fields
 
   /**
@@ -120,7 +120,7 @@ export class PaginationEmbed extends MessageEmbed {
    * The embeds if paginating through embeds.
    * @default []
    */
-  public embeds: MessageEmbed[];
+  public embeds: Embed[];
 
   /**
    * The attachments to show with the paginated messages.
@@ -433,11 +433,11 @@ export class PaginationEmbed extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()]);
+   *  .setEmbeds([new Embed(), new Embed(), new Embed()]);
    * ```
    *
    */
-  setEmbeds(embeds: MessageEmbed[]): this {
+  setEmbeds(embeds: Embed[]): this {
     this.embeds = embeds;
     this.limit = 1;
     return this;
@@ -450,12 +450,12 @@ export class PaginationEmbed extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()])
-   *  .addEmbed(new MessageEmbed);
+   *  .setEmbeds([new Embed(), new Embed(), new Embed()])
+   *  .addEmbed(new Embed);
    * ```
    *
    */
-  addEmbed(embed: MessageEmbed): this {
+  addEmbed(embed: Embed): this {
     this.embeds.push(embed);
     return this;
   }
@@ -467,12 +467,12 @@ export class PaginationEmbed extends MessageEmbed {
    * @example
    * ```javascript
    * const pagination = new Pagination(interaction)
-   *  .setEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()])
-   *  .addEmbeds([new MessageEmbed(), new MessageEmbed(), new MessageEmbed()]);
+   *  .setEmbeds([new Embed(), new Embed(), new Embed()])
+   *  .addEmbeds([new Embed(), new Embed(), new Embed()]);
    * ```
    *
    */
-  addEmbeds(embeds: MessageEmbed[]): this {
+  addEmbeds(embeds: Embed[]): this {
     this.embeds.push(...embeds);
     return this;
   }


### PR DESCRIPTION
Closes #8. Allows users to provide a custom Embed class to use in the program. Defaults to Discord.js' MessageEmbed class.