### PR TITLE
fix: update deprecated MessageFlags.Ephemeral implementation

### DIFF
--- a/src/lib/pagination/Pagination.ts
+++ b/src/lib/pagination/Pagination.ts
@@ -2,6 +2,7 @@ import {
 	BaseInteraction,
 	ComponentType,
 	Message,
+	MessageFlags,
 	MessageComponentInteraction,
 	type ButtonInteraction,
 	type CommandInteraction,

--- a/src/lib/pagination/PaginationEmbed.ts
+++ b/src/lib/pagination/PaginationEmbed.ts
@@ -9,7 +9,8 @@ import {
 	type ComponentEmojiResolvable,
 	type JSONEncodable,
 	type MessageActionRowComponentBuilder,
-	type RestOrArray
+	type RestOrArray,
+	MessageFlags
 } from 'discord.js';
 
 import { defaultOptions } from './defaultOptions.js';
@@ -1036,7 +1037,9 @@ export abstract class PaginationEmbed extends EmbedBuilder {
 	 */
 	private _readyPayloads(): Payload {
 		this._readyActionRows();
-		this.payload.ephemeral = this.ephemeral;
+		if (this.ephemeral) {
+			this.payload.flags = MessageFlags.Ephemeral;
+		}
 		this.payload.components = this.actionRows;
 		this.payload.content = (Array.isArray(this.contents) ? this.contents[0] : this.contents) ?? undefined;
 		const embed = this.embeds.length ? EmbedBuilder.from(this.embeds[0]) : this;

--- a/src/lib/types/Payload.ts
+++ b/src/lib/types/Payload.ts
@@ -1,5 +1,5 @@
-import type { BaseMessageOptions } from 'discord.js';
+import type { BaseMessageOptions, InteractionReplyOptions } from 'discord.js';
 
-export type Payload = BaseMessageOptions & {
+export type Payload = (BaseMessageOptions & InteractionReplyOptions) & {
 	ephemeral?: boolean;
 };


### PR DESCRIPTION
# Update Deprecated MessageFlags.Ephemeral Implementation

## Description
This PR updates the library to use the current recommended approach for handling ephemeral messages in Discord.js v14, replacing the deprecated direct `ephemeral` property usage with `MessageFlags.Ephemeral`.

## Changes
- Updated `Payload` type to extend both `BaseMessageOptions` and `InteractionReplyOptions`
- Modified `_readyPayloads` method to use `MessageFlags.Ephemeral` instead of direct property
- Maintained backward compatibility with existing `ephemeral` option in user-facing methods

## Issues that should be resolved:

https://github.com/imranbarbhuiya/pagination.djs/issues/360

Have a great day,

A happy user.
